### PR TITLE
Supporting 3-rd party detectors (rules)

### DIFF
--- a/huntbugs/src/main/java/one/util/huntbugs/spi/HuntBugsPlugin.java
+++ b/huntbugs/src/main/java/one/util/huntbugs/spi/HuntBugsPlugin.java
@@ -1,0 +1,10 @@
+package one.util.huntbugs.spi;
+
+/**
+ * This is extension point for 3-rd party detector providers.
+ *
+ * @author Mihails Volkovs
+ *
+ */
+public interface HuntBugsPlugin {
+}


### PR DESCRIPTION
We would like to write our own project specific rules. So, this is currently a working solution for Maven. I didn't tested Ant or Gradle, but should be as simple as adding your artifact (with custom detectors) to (HuntBugs plugin) classpath.

- multiple messages.xml are read and merged
- Java SPI mechanism for discovering 3-rd party detectors
- default detector package is still needs to be used
- huntbugs maven plugin is not affected (to configure it standard tag 'dependencies' inside tag 'plugin' could be used)
- removed redundant public modifiers at interface nested classes (public by default)

What do you think?