### PR TITLE
Supporting pom type and transitive dependencies (#17)

### DIFF
--- a/huntbugs-maven-plugin/pom.xml
+++ b/huntbugs-maven-plugin/pom.xml
@@ -26,6 +26,11 @@
       <version>3.2.1</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-dependency-tree</artifactId>
+      <version>2.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <version>3.2</version>


### PR DESCRIPTION
 - traversing dependencies tree
 - collecting compile time dependencies
 - understanding POM type dependencies
 - understanding other transitive dependencies
 - understanding excluded transitive dependencies
 - new dependency org.apache.maven.shared:maven-dependency-tree is required
 - @Component annotation is used for Mojo injection (since May, 2012)