### PR TITLE
Custom detectors demo

### DIFF
--- a/huntbugs/src/main/java/one/util/huntbugs/spi/DataTests.java
+++ b/huntbugs/src/main/java/one/util/huntbugs/spi/DataTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 HuntBugs contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.util.huntbugs.spi;
+
+import one.util.huntbugs.analysis.AnalysisOptions;
+import one.util.huntbugs.analysis.Context;
+import one.util.huntbugs.analysis.ErrorMessage;
+import one.util.huntbugs.analysis.HuntBugsResult;
+import one.util.huntbugs.input.XmlReportReader;
+import one.util.huntbugs.output.Reports;
+import one.util.huntbugs.repo.CompositeRepository;
+import one.util.huntbugs.repo.Repository;
+
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+
+/**
+ * @author Tagir Valeev
+ *
+ */
+public abstract class DataTests {
+
+    public static void test(String packageToAnalyze) throws Exception {
+
+        // creating built-in and plugins repositories
+        List<Repository> repositories = new ArrayList<>();
+        repositories.add(Repository.createSelfRepository());
+        for (HuntBugsPlugin huntBugsPlugin : ServiceLoader.load(HuntBugsPlugin.class)) {
+            repositories.add(Repository.createPluginRepository(huntBugsPlugin));
+        }
+        CompositeRepository repository = new CompositeRepository(repositories);
+
+        Context ctx = new Context(repository, new AnalysisOptions());
+        ctx.analyzePackage(packageToAnalyze);
+        ctx.reportStats(System.out);
+        ctx.reportErrors(System.err);
+        ctx.reportWarnings(new PrintStream("target/testWarnings.out"));
+        Path xmlReport = Paths.get("target/testWarnings.xml");
+        Reports.write(xmlReport, Paths.get("target/testWarnings.html"), ctx);
+        System.out.println("Analyzed " + ctx.getClassesCount() + " classes");
+        if (ctx.getErrorCount() > 0) {
+            List<ErrorMessage> errorMessages = ctx.errors().collect(Collectors.toList());
+            throw new AssertionError(format("Analysis finished with %s errors: %s", ctx.getErrorCount(), errorMessages));
+        }
+        HuntBugsResult result = XmlReportReader.read(ctx, xmlReport);
+        Path rereadReport = Paths.get("target/testWarnings_reread.xml");
+        Reports.write(rereadReport, null, result);
+        byte[] expectedReport = Files.readAllBytes(xmlReport);
+        byte[] actualReport = Files.readAllBytes(rereadReport);
+        if (!Arrays.equals(expectedReport, actualReport)) {
+            String errorMessage = format("Expected: \n%s\n\nActual: \n%s\n\n", new String(expectedReport), new String(actualReport));
+            throw new AssertionError(errorMessage);
+        }
+    }
+
+}

--- a/huntbugs/src/main/java/one/util/huntbugs/spi/HuntBugsPlugin.java
+++ b/huntbugs/src/main/java/one/util/huntbugs/spi/HuntBugsPlugin.java
@@ -1,31 +1,30 @@
 /*
  * Copyright 2016 HuntBugs contributors
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package one.util.huntbugs;
-
-import one.util.huntbugs.spi.DataTests;
-import org.junit.Test;
+package one.util.huntbugs.spi;
 
 /**
- * @author Tagir Valeev
+ * This is extension point for 3-rd party detector providers.
+ *
+ * @author Mihails Volkovs
+ *
  */
-public class DataTest {
+public interface HuntBugsPlugin {
 
-    @Test
-    public void test() throws Exception {
-        DataTests.test("one/util/huntbugs/testdata");
-    }
+    String name();
+
+    String detectorPackage();
 
 }

--- a/huntbugs/src/test/java/one/util/huntbugs/registry/DetectorRegistryTest.java
+++ b/huntbugs/src/test/java/one/util/huntbugs/registry/DetectorRegistryTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 HuntBugs contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.util.huntbugs.registry;
+
+import one.util.huntbugs.analysis.AnalysisOptions;
+import one.util.huntbugs.analysis.Context;
+import one.util.huntbugs.registry.anno.WarningDefinition;
+import one.util.huntbugs.repo.Repository;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Mihails Volkovs
+ */
+public class DetectorRegistryTest {
+
+    private Context context;
+
+    private DetectorRegistry detectorRegistry;
+
+    @Before
+    public void setUp() {
+        context = new Context(Repository.createNullRepository(), new AnalysisOptions());
+        detectorRegistry = new DetectorRegistry(context);
+    }
+
+    @Test
+    public void addDetector() {
+        final long WARNINGS = getWarnings();
+        assertTrue(detectorRegistry.addDetector(TestDetector.class));
+        assertEquals(WARNINGS + 2, getWarnings());
+    }
+
+    @Test
+    public void addFakeDetector() {
+        final long WARNINGS = getWarnings();
+        assertFalse(detectorRegistry.addDetector(DetectorRegistryTest.class));
+        assertEquals(WARNINGS, getWarnings());
+    }
+
+    private long getWarnings() {
+        return context.getStat("WarningTypes.Total");
+    }
+
+    @WarningDefinition(category="DetectorRegistryTest", name="DetectorRegistryTest", maxScore=80)
+    @WarningDefinition(category="DetectorRegistryTest", name="DetectorRegistryTest", maxScore=80)
+    private static class TestDetector {
+
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
   <module>huntbugs</module>
   <module>huntbugs-ant-plugin</module>
   <module>huntbugs-maven-plugin</module>
+  <module>sample-huntbugs-custom-detector</module>
+  <module>sample-project</module>
  </modules>
 
  <distributionManagement>

--- a/sample-huntbugs-custom-detector/pom.xml
+++ b/sample-huntbugs-custom-detector/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+ <modelVersion>4.0.0</modelVersion>
+
+ <parent>
+  <groupId>one.util</groupId>
+  <artifactId>huntbugs-all</artifactId>
+  <version>0.0.11-SNAPSHOT</version>
+ </parent>
+ <artifactId>sample-huntbugs-custom-detector</artifactId>
+ <packaging>jar</packaging>
+
+ <name>sample-huntbugs-custom-detector</name>
+ <description>Demonstration of how HuntBugs custom detectors could be implemented</description>
+
+ <dependencies>
+  <dependency>
+   <groupId>one.util</groupId>
+    <artifactId>huntbugs</artifactId>
+    <version>${project.version}</version>
+    <scope>provided</scope>
+   </dependency>
+   <dependency>
+    <groupId>junit</groupId>
+    <artifactId>junit</artifactId>
+    <version>4.12</version>
+    <scope>test</scope>
+   </dependency>
+ </dependencies>
+
+</project>

--- a/sample-huntbugs-custom-detector/src/main/java/one/util/huntbugs/sample/SampleHuntBugsPlugin.java
+++ b/sample-huntbugs-custom-detector/src/main/java/one/util/huntbugs/sample/SampleHuntBugsPlugin.java
@@ -1,31 +1,35 @@
 /*
  * Copyright 2016 HuntBugs contributors
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package one.util.huntbugs;
+package one.util.huntbugs.sample;
 
-import one.util.huntbugs.spi.DataTests;
-import org.junit.Test;
+import one.util.huntbugs.spi.HuntBugsPlugin;
 
 /**
- * @author Tagir Valeev
+ * @author Mihails Volkovs
  */
-public class DataTest {
+public class SampleHuntBugsPlugin implements HuntBugsPlugin {
 
-    @Test
-    public void test() throws Exception {
-        DataTests.test("one/util/huntbugs/testdata");
+    @Override
+    public String name() {
+        return "Sample Detectors";
+    }
+
+    @Override
+    public String detectorPackage() {
+        return "one.util.huntbugs.sample.detect";
     }
 
 }

--- a/sample-huntbugs-custom-detector/src/main/java/one/util/huntbugs/sample/detect/SampleCustomDetector.java
+++ b/sample-huntbugs-custom-detector/src/main/java/one/util/huntbugs/sample/detect/SampleCustomDetector.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 HuntBugs contributors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.util.huntbugs.sample.detect;
+
+import com.strobel.assembler.metadata.MethodDefinition;
+import com.strobel.assembler.metadata.TypeDefinition;
+import com.strobel.assembler.metadata.TypeReference;
+import one.util.huntbugs.registry.MethodContext;
+import one.util.huntbugs.registry.anno.MethodVisitor;
+import one.util.huntbugs.registry.anno.WarningDefinition;
+import one.util.huntbugs.util.Types;
+
+/**
+ * @author Mihails Volkovs
+ */
+@WarningDefinition(category="Demo", name="SampleCustomDetector", maxScore=80)
+public class SampleCustomDetector {
+
+    @MethodVisitor
+    public void visit(MethodContext mc, MethodDefinition md, TypeDefinition td) {
+        TypeReference returnType = md.getReturnType();
+        if (Types.isCollection(returnType)) {
+            mc.report("SampleCustomDetector", 5);
+        }
+    }
+}

--- a/sample-huntbugs-custom-detector/src/main/resources/META-INF/services/one.util.huntbugs.spi.HuntBugsPlugin
+++ b/sample-huntbugs-custom-detector/src/main/resources/META-INF/services/one.util.huntbugs.spi.HuntBugsPlugin
@@ -1,0 +1,1 @@
+one.util.huntbugs.sample.SampleHuntBugsPlugin

--- a/sample-huntbugs-custom-detector/src/main/resources/huntbugs/messages.xml
+++ b/sample-huntbugs-custom-detector/src/main/resources/huntbugs/messages.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:Messages
+  xmlns:p="https://raw.githubusercontent.com/amaembo/huntbugs/master/huntbugs/src/main/resources/huntbugs"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://raw.githubusercontent.com/amaembo/huntbugs/master/huntbugs/src/main/resources/huntbugs messages.xsd">
+  <WarningList>
+    <Warning Type="SampleCustomDetector">
+      <Title>For some reason you can't return instance of java.util.Collection</Title>
+      <Description>For some reason you can't return instance of java.util.Collection</Description>
+      <LongDescription><![CDATA[For some reason you can't return instance of java.util.Collection]]></LongDescription>
+    </Warning>
+  </WarningList>
+</p:Messages>

--- a/sample-huntbugs-custom-detector/src/test/java/one/util/huntbugs/sample/DataTest.java
+++ b/sample-huntbugs-custom-detector/src/test/java/one/util/huntbugs/sample/DataTest.java
@@ -13,19 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package one.util.huntbugs;
+package one.util.huntbugs.sample;
 
 import one.util.huntbugs.spi.DataTests;
 import org.junit.Test;
 
 /**
- * @author Tagir Valeev
+ * @author Mihails Volkovs
  */
 public class DataTest {
 
     @Test
     public void test() throws Exception {
-        DataTests.test("one/util/huntbugs/testdata");
+        DataTests.test("one/util/huntbugs/sample/testdata");
     }
 
 }

--- a/sample-huntbugs-custom-detector/src/test/java/one/util/huntbugs/sample/testdata/TestSampleCustomDetector.java
+++ b/sample-huntbugs-custom-detector/src/test/java/one/util/huntbugs/sample/testdata/TestSampleCustomDetector.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 HuntBugs contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.util.huntbugs.sample.testdata;
+
+import one.util.huntbugs.registry.anno.AssertNoWarning;
+import one.util.huntbugs.registry.anno.AssertWarning;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Mihails Volkovs
+ */
+public class TestSampleCustomDetector {
+
+    private static final String DEMO_CUSTOM_DETECTOR = "SampleCustomDetector";
+
+    @AssertWarning(DEMO_CUSTOM_DETECTOR)
+    public Collection getCollection() {
+        return new ArrayList();
+    }
+
+    @AssertNoWarning(DEMO_CUSTOM_DETECTOR)
+    public Map getMap() {
+        return new HashMap();
+    }
+
+}

--- a/sample-project/pom.xml
+++ b/sample-project/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>one.util</groupId>
+        <artifactId>huntbugs-all</artifactId>
+        <version>0.0.11-SNAPSHOT</version>
+    </parent>
+    <artifactId>sample-project</artifactId>
+    <packaging>jar</packaging>
+
+    <name>sample-project</name>
+    <description>Sample project to demonstrate HuntBugs configuration and features</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>one.util</groupId>
+                <artifactId>huntbugs-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>one.util</groupId>
+                        <artifactId>sample-huntbugs-custom-detector</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>huntbugs-check</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>huntbugs</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sample-project/src/main/java/one/util/huntbugs/sample/MyProductionCode.java
+++ b/sample-project/src/main/java/one/util/huntbugs/sample/MyProductionCode.java
@@ -1,31 +1,30 @@
 /*
  * Copyright 2016 HuntBugs contributors
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package one.util.huntbugs;
+package one.util.huntbugs.sample;
 
-import one.util.huntbugs.spi.DataTests;
-import org.junit.Test;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * @author Tagir Valeev
+ * @author Mihails Volkovs
  */
-public class DataTest {
+public class MyProductionCode {
 
-    @Test
-    public void test() throws Exception {
-        DataTests.test("one/util/huntbugs/testdata");
+    public List<String> bugsAlive() {
+        return new ArrayList<>();
     }
 
 }

--- a/sample-project/src/test/java/one/util/huntbugs/sample/MyProductionCodeTest.java
+++ b/sample-project/src/test/java/one/util/huntbugs/sample/MyProductionCodeTest.java
@@ -1,31 +1,40 @@
 /*
  * Copyright 2016 HuntBugs contributors
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package one.util.huntbugs;
+package one.util.huntbugs.sample;
 
-import one.util.huntbugs.spi.DataTests;
+import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertTrue;
+
 /**
- * @author Tagir Valeev
+ * @author Mihails Volkovs
  */
-public class DataTest {
+public class MyProductionCodeTest {
+
+    private MyProductionCode productionCode;
+
+    @Before
+    public void setUp() {
+        productionCode = new MyProductionCode();
+    }
 
     @Test
-    public void test() throws Exception {
-        DataTests.test("one/util/huntbugs/testdata");
+    public void bugsAlive() {
+        assertTrue(productionCode.bugsAlive().isEmpty());
     }
 
 }


### PR DESCRIPTION
This PR is based on (and contains) https://github.com/amaembo/huntbugs/pull/16 to demonstrate development of custom detector and their usage in sample project:

- multiple messages.xml are read and merged
- Java SPI mechanism for discovering 3-rd party detectors
- default detector package is still needs to be used
- huntbugs maven plugin is not affected (to configure it standard tag 'dependencies' inside tag 'plugin' could be used)
- removed redundant public modifiers at interface nested classes (public by default)
- plugin currently supports single package for detectors
- introducing helper class to test detectors (to be reused)
- custom detectors can be located in custom packages
- minor refactoring
- added license agreement headers
- demonstrating development of custom detector
- sample project for custom detectors
- detectors are automatically tested with sample code in test scope
- sample project with HuntBugs maven plugin with custom detectors
- production code in sample project is not annotated with @AssertWarning
- sample project might be used for demonstration of project configuration without custom detectors as well