### PR TITLE
Add $deserializeLambda$ to a set of known serialization-related methods

### DIFF
--- a/huntbugs/src/main/java/one/util/huntbugs/util/Methods.java
+++ b/huntbugs/src/main/java/one/util/huntbugs/util/Methods.java
@@ -38,7 +38,7 @@ import one.util.huntbugs.warning.WarningAnnotation.MemberInfo;
 public class Methods {
     private static final Set<String> SERIALIZATION_METHODS = 
             new HashSet<>(Arrays.asList("writeReplace", "readResolve",
-                "readObject", "readObjectNoData", "writeObject"));
+                "readObject", "readObjectNoData", "writeObject", "$deserializeLambda$"));
     
     public static boolean isEqualsMethod(MethodReference mr) {
         return mr.getName().equals("equals") && mr.getSignature().equals("(Ljava/lang/Object;)Z");


### PR DESCRIPTION
Fixes #31

I'm not sure how to add a test. I tried to add
```java
    @AssertNoWarning("UncalledPrivateMethod")
    private static class SerializedClass implements Serializable {
        private int foo;

        private Runnable foo() {
            return () -> {
                System.out.println(foo);
            };
        }
    }
```
but that's passing even without the patch. I guess I'd need to annotate the `$deserializeLambda$` method, but the method is generated by Java compiler. 